### PR TITLE
Backend upload images janri

### DIFF
--- a/app/backend/src/models/reported_fires.py
+++ b/app/backend/src/models/reported_fires.py
@@ -13,7 +13,7 @@ class FireReports(Base):
     user_id = Column(String, ForeignKey("users.id", ondelete="SET NULL"), nullable=True) 
     reporter_ip = Column(String, nullable=True)
     description = Column(String, nullable=True)
-    image_url = Column(String, nullable=False)
+    image_url = Column(String, nullable=True)
     location_text = Column(Text, nullable=False)
     location_geom = Column(Geometry(geometry_type="POINT", srid=4326, spatial_index=True), nullable=False)
     boundary_radius = Column(Numeric(5,2), nullable=False)

--- a/app/backend/src/schemas/fire_report.py
+++ b/app/backend/src/schemas/fire_report.py
@@ -8,7 +8,7 @@ class FireReportCreate(BaseModel):
     lng: float = Field(...,ge=-180, le=180)
     location_text:str = Field(..., min_length=3, max_length=255)
     description:Optional[str] = Field(default=None, max_length=1000)
-    image_url: str  # Stores a minio object_key returned from POST /api/uploads/images. Not a public url, resolved to short-lived presigned url on read
+    image_url: Optional[str] = None
     boundary_radius: float = Field(..., gt=0, le=50)
 
 class FireReportMapResponse(BaseModel):

--- a/app/backend/src/services/storage.py
+++ b/app/backend/src/services/storage.py
@@ -11,6 +11,16 @@ minio_client = Minio(
     access_key=os.environ["MINIO_ACCESS_KEY"],
     secret_key=os.environ["MINIO_SECRET_KEY"],
     secure=os.environ.get("MINIO_SECURE", "false").lower() == "true",
+    region="us-east-1",
+)
+
+# Separate client only for generating presigned URLs, using the browser-reachable endpoint
+presign_client = Minio(
+    os.environ.get("MINIO_PUBLIC_ENDPOINT", "localhost:9000"),
+    access_key=os.environ["MINIO_ACCESS_KEY"],
+    secret_key=os.environ["MINIO_SECRET_KEY"],
+    secure=os.environ.get("MINIO_SECURE", "false").lower() == "true",
+    region="us-east-1",
 )
 
 BUCKET = os.environ["MINIO_BUCKET"]
@@ -43,10 +53,10 @@ def upload_image(filename: str, content_type: str, contents: bytes) -> str:
     
     return object_key
 
-def get_presigned_url(object_key: Optional[str], expires_minutes: int = 10) -> Optional[str]:
+def get_presigned_url(object_key: Optional[str], expires_minutes: int = 60) -> Optional[str]:
     if not object_key:
         return None
-    return minio_client.presigned_get_object(
+    return presign_client.presigned_get_object(
         BUCKET,
         object_key,
         expires=timedelta(minutes=expires_minutes),

--- a/app/backend/src/services/storage.py
+++ b/app/backend/src/services/storage.py
@@ -4,6 +4,7 @@ import uuid
 from datetime import timedelta
 from io import BytesIO
 from minio import Minio
+from typing import Optional
 
 minio_client = Minio(
     os.environ["MINIO_ENDPOINT"],
@@ -42,7 +43,9 @@ def upload_image(filename: str, content_type: str, contents: bytes) -> str:
     
     return object_key
 
-def get_presigned_url(object_key: str, expires_minutes: int = 10) -> str:
+def get_presigned_url(object_key: Optional[str], expires_minutes: int = 10) -> Optional[str]:
+    if not object_key:
+        return None
     return minio_client.presigned_get_object(
         BUCKET,
         object_key,

--- a/app/backend/src/services/users/fire_report.py
+++ b/app/backend/src/services/users/fire_report.py
@@ -61,7 +61,7 @@ def get_fire_report_by_id(report_id: str, db: Session):
         "lat": lat,
         "lng": lng,
         "description": report.description,
-        "image_url": report.image_url,
+        "image_url": get_presigned_url(report.image_url),
         "status": report.status,
         "status_index": report.status_index,
         "boundary_radius": float(report.boundary_radius),

--- a/app/frontend/src/components/reportfire/report.tsx
+++ b/app/frontend/src/components/reportfire/report.tsx
@@ -69,7 +69,7 @@ export default function ReportPage() {
     setSubmitState("loading");
     setSubmitError(null);
     try {
-      let imageUrl = "";
+      let imageUrl: string | undefined = undefined;
 
       if (data.photo){  // upload image first if one was attatched
         const formData = new FormData();
@@ -100,6 +100,11 @@ export default function ReportPage() {
           boundary_radius: boundarySize,
         }),
       });
+
+      if (!res.ok) {
+        throw new Error("Failed to submit report");
+      }
+
       const report = await res.json();
       setActiveRefNum(report.reference_number);
       setStatusIndex(0);
@@ -108,7 +113,7 @@ export default function ReportPage() {
       setTimeout(() => {
         setActiveStep(0);
         setLocation('Click the map to drop a pin');
-        setBoundarySize(2);
+        setBoundarySize(200);
         setExternalPin(null);
         setMapKey((k) => k + 1);
       }, 1000);


### PR DESCRIPTION
- Added a separate MinIO client for presigning, using MINIO_PUBLIC_ENDPOINT so that the browser can display image
- Added explicit region to MinIO clients 
- Made image_url nullable
- Bumped presigned URL expiry to 60 minutes (more realistic than 10 mins)
- Tested end-to-end: upload -> MinIO -> DB -> presigned URL -> display

**Requires .env update:** 
