### PR TITLE
Dca implementation

### DIFF
--- a/app/backend/src/ai/dca.py
+++ b/app/backend/src/ai/dca.py
@@ -1,9 +1,31 @@
+import torch
 from pytorchfire import WildfireModel
+import numpy as np
 
-model = WildfireModel() # creates a model with default params and environment data
-model = model.cuda() # move model to gpu
+from .ignition import IgnitionScorer
+from .schema import UNBURNED
+from .simulation import pick_ignition_points, build_env_data, state_to_burn_state
 
-for _ in range(100): # runs model for 100 steps
-    model.compute()
+def run_dca(weather_grids: dict, static_grids: dict, n_steps: int = 100, n_ignition_points: int=1, params: dict | None = None):
 
-    # reference is the study done for pytorch by MIT this is just a base modal is gonna be modified to not use the other variables but to use the ignition from the xgboost
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    H, W = static_grids["elevation"].shape
+    burn_state0 = np.full((H, W), UNBURNED, dtype=np.int64)
+
+    scorer = IgnitionScorer.load()
+    p_ignite = scorer.score_grid(weather_grids, static_grids, burn_state0)
+    ignition_mask = pick_ignition_points(p_ignite, n_points=n_ignition_points)
+    env_data = build_env_data(weather_grids, static_grids, ignition_mask)
+
+    model = WildfireModel(env_data=env_data, params=params).to(device)
+    model.eval()
+
+    history = [state_to_burn_state(model.state)]
+
+    with torch.no_grad():
+        for _ in range(n_steps):
+            model.compute()
+            history.append(state_to_burn_state(model.state))
+
+    return history

--- a/app/backend/src/ai/dca.py
+++ b/app/backend/src/ai/dca.py
@@ -1,4 +1,4 @@
-from pytorch import WildfireModel
+from pytorchfire import WildfireModel
 
 model = WildfireModel() # creates a model with default params and environment data
 model = model.cuda() # move model to gpu

--- a/app/backend/src/ai/dca.py
+++ b/app/backend/src/ai/dca.py
@@ -1,1 +1,9 @@
-# TODO: Later. 
+from pytorch import WildfireModel
+
+model = WildfireModel() # creates a model with default params and environment data
+model = model.cuda() # move model to gpu
+
+for _ in range(100): # runs model for 100 steps
+    model.compute()
+
+    # reference is the study done for pytorch by MIT this is just a base modal is gonna be modified to not use the other variables but to use the ignition from the xgboost

--- a/app/backend/src/ai/ignition.py
+++ b/app/backend/src/ai/ignition.py
@@ -20,7 +20,7 @@ class IgnitionScorer:   # The only interface backend/simulation loop needs
         self.booster.set_param({"nthread": 2, "device": "cpu"})
         
     @classmethod
-    def load(cls, version: str = "LASTEST") -> "IgnitionScorer":
+    def load(cls, version: str = "LATEST") -> "IgnitionScorer":
         """ Load a published model from the artifact store by version name or current latest.
             Verifies training-time schema matches this code - guard that matters when models are trained on different machine than the one serving them
         """

--- a/app/backend/src/ai/run_ai_pipeline.py
+++ b/app/backend/src/ai/run_ai_pipeline.py
@@ -1,0 +1,48 @@
+import numpy as np
+import torch
+
+from .dca import run_dca
+
+def test_grid(H: int = 30, W: int =30) -> tuple[dict, dict]:
+    weather_grids = {
+        "wind_u": np.full((H,W), 3.0, dtype=np.float32),
+        "wind_v": np.full((H,W), 1.0, dtype=np.float32),
+        "rel_humidity": np.full((H,W), 35.0, dtype=np.float32),
+        "temperature": np.full((H,W), 28.0, dtype=np.float32),
+    }
+
+    static_grids ={
+        "elevation": np.zeros((H,W), dtype=np.float32),
+        "slope": np.zeros((H,W), dtype=np.float32),
+        "aspect_sin": np.zeros((H,W), dtype=np.float32),
+        "aspect_cos": np.zeros((H,W), dtype=np.float32),
+        "fuel_load": np.full((H,W), 0.5, dtype=np.float32),
+        "dryness": np.full((H,W), 0.5, dtype=np.float32),
+    }
+
+    return weather_grids, static_grids
+
+def main():
+    weather_grids, static_grids = test_grid()
+
+    params = {
+        "a": torch.tensor(0.1),
+        "p_h": torch.tensor(0.4),
+        "c_1": torch.tensor(0.1),
+        "c_2": torch.tensor(0.1),
+        "p_continue": torch.tensor(0.6),
+    }
+
+    print(f"DCA is running | device currently being used: device={'cuda' if torch.cuda.is_available else 'cpu'}")
+    history = run_dca(weather_grids, static_grids, n_steps=15, params=params)
+
+    print(f"\n{'tick':>4} | {'burning':>8} | {'burned':>7}")
+    print("-"*6)
+
+    for t, grid in enumerate(history):
+        burning_count = int((grid == 1).sum())
+        burned_count = int((grid == 2).sum())
+        print(f"{t:>4} | {burning_count:>8} | {burned_count:>7}")
+
+if __name__ == "__main__":
+    main()

--- a/app/backend/src/ai/simulation.py
+++ b/app/backend/src/ai/simulation.py
@@ -1,1 +1,25 @@
-# TODO: Later. Tick look binding all 3 model aspects
+import torch
+import numpy as np
+from .ignition import IgnitionScorer
+from .schema import UNBURNED, BURNING, BURNED 
+
+# p_ignite is the output from the ignition scorer and is a 2D shape [H, W] and one probability per cell
+# n_points is how many cells we want to turn into ignition points(sparks) the default is 1
+# rng an optional random number generator that can be passed for a caller to control reproducibility, good for testing the simulation
+# Return type is a boolean grid same shape as p_ignite, True where fire starts
+# what is does: This function converts a continuous ignition-risk heatmap provided by the xgboost into a small number of discrete, randomly but probability weighted fire start points
+# formated as a boolean grid that is expected by PyTorchFire
+def pick_ignition_points(p_ignite: np.ndarray, n_points: int = 1, rng=None) -> np.ndarray: 
+    rng = rng or np.random.default_rng()
+    flat_p = p_ignite.ravel().astype(np.float64) # flattens the array into a 1D array
+
+    if flat_p.sum() <= 0:
+        raise ValueError("No ignition-prone cells: all P(ingite) are zero")
+    flat_p /= flat_p.sum()
+
+    idx = rng.choice(flat_p.size, size=n_points, replace=False, p=flat_p)
+
+    mask = np.zeros(p_ignite.shape, dtype=bool)
+    mask.flat[idx] = True # this is an iterator view over the 2D array, that maps the flattend postitions back onto the original 2D grid position
+    return mask
+

--- a/app/backend/src/ai/simulation.py
+++ b/app/backend/src/ai/simulation.py
@@ -7,8 +7,6 @@ from .schema import UNBURNED, BURNING, BURNED
 # n_points is how many cells we want to turn into ignition points(sparks) the default is 1
 # rng an optional random number generator that can be passed for a caller to control reproducibility, good for testing the simulation
 # Return type is a boolean grid same shape as p_ignite, True where fire starts
-# what is does: This function converts a continuous ignition-risk heatmap provided by the xgboost into a small number of discrete, randomly but probability weighted fire start points
-# formated as a boolean grid that is expected by PyTorchFire
 def pick_ignition_points(p_ignite: np.ndarray, n_points: int = 1, rng=None) -> np.ndarray: 
     rng = rng or np.random.default_rng()
     flat_p = p_ignite.ravel().astype(np.float64) # flattens the array into a 1D array
@@ -23,19 +21,27 @@ def pick_ignition_points(p_ignite: np.ndarray, n_points: int = 1, rng=None) -> n
     mask.flat[idx] = True # this is an iterator view over the 2D array, that maps the flattend postitions back onto the original 2D grid position
     return mask
 
-def build_env_data(weather_np: dict, static_np: dict, initial_ignition_mask: np.ndarray) -> dict:
+def build_env_data(weather_grids: dict, static_grids: dict, initial_ignition_mask: np.ndarray) -> dict:
 
-    u = torch.from_numpy(weather_np["wind_u"]).float()
-    v = torch.from_numpy(weather_np["wind_v"]).float()
+    wind_u_comp = torch.from_numpy(weather_grids["wind_u"]).float()
+    wind_v_comp = torch.from_numpy(weather_grids["wind_v"]).float()
 
-    wind_velocity = torch.sqrt(u**2 + v**2)
-    wind_towards_direction = torch.rad2deg(torch.atan2(v,u)) % 360
+    wind_velocity = torch.sqrt(wind_u_comp **2 + wind_v_comp**2)
+    wind_towards_direction = torch.rad2deg(torch.atan2(wind_v_comp,wind_u_comp )) % 360
 
     return {
-        "p_veg": torch.from_numpy(static_np["fuel_load"]).float(),
-        "p_den": torch.from_numpy(static_np["dryness"]).float(),
+        "p_veg": torch.from_numpy(static_grids["fuel_load"]).float(),
+        "p_den": torch.from_numpy(static_grids["dryness"]).float(),
         "wind_velocity": wind_velocity,
         "wind_towards_direction": wind_towards_direction,
         "slope": torch.zeros((*wind_velocity.shape, 3, 3), dtype=torch.float32),
         "initial_ignition": torch.from_numpy(initial_ignition_mask).bool(),
     }
+
+def state_to_burn_state(state: torch.Tensor) -> np.ndarray:
+    #convert the Pytorchfire [2, H. W] bool state to schema.py's [H,W] int codes
+    burning, burned = state.detach().cpu().numpy()
+    burn_state_grid = np.full(burning.shape, UNBURNED, dtype=np.int64)
+    burn_state_grid[burning] = BURNING
+    burn_state_grid[burned] = BURNED
+    return burn_state_grid

--- a/app/backend/src/ai/simulation.py
+++ b/app/backend/src/ai/simulation.py
@@ -23,3 +23,19 @@ def pick_ignition_points(p_ignite: np.ndarray, n_points: int = 1, rng=None) -> n
     mask.flat[idx] = True # this is an iterator view over the 2D array, that maps the flattend postitions back onto the original 2D grid position
     return mask
 
+def build_env_data(weather_np: dict, static_np: dict, initial_ignition_mask: np.ndarray) -> dict:
+
+    u = torch.from_numpy(weather_np["wind_u"]).float()
+    v = torch.from_numpy(weather_np["wind_v"]).float()
+
+    wind_velocity = torch.sqrt(u**2 + v**2)
+    wind_towards_direction = torch.rad2deg(torch.atan2(v,u)) % 360
+
+    return {
+        "p_veg": torch.from_numpy(static_np["fuel_load"]).float(),
+        "p_den": torch.from_numpy(static_np["dryness"]).float(),
+        "wind_velocity": wind_velocity,
+        "wind_towards_direction": wind_towards_direction,
+        "slope": torch.zeros((*wind_velocity.shape, 3, 3), dtype=torch.float32),
+        "initial_ignition": torch.from_numpy(initial_ignition_mask).bool(),
+    }

--- a/app/backend/src/requirements.txt
+++ b/app/backend/src/requirements.txt
@@ -17,3 +17,7 @@ requests
 pyjwt>=2.8
 pydantic>=2.0
 minio
+numpy
+torch
+pytorchfire
+xgboost

--- a/docs/run_ai_pipeline.md
+++ b/docs/run_ai_pipeline.md
@@ -1,0 +1,37 @@
+# In the terminal, run the following commands to run the DCA simulation
+
+- Note: This is dependent on the XGBoost ignition model already being trained and published. Run the commands in the run_XGBoost.md before the commands in this document.
+
+1. Ensure you are in the project root and the same environment variables from the ignition training are still in terminal session.
+```base
+export FIRE_ARTIFACT_STORE=/tmp/fire-test-score
+export PYTHONPATH=app/backend/src:app/ml
+```
+
+2. Run the dca pipeline. Uses the ignition scores from xgboost model and the runs the CA from PyTorchFire
+```bash
+python -m app.backend.src.ai.run_ai_pipeline
+```
+
+3. Output should be similar to the following:
+
+DCA is running | device currently being used: device=cuda
+
+tick |  burning |  burned
+------
+   0 |        1 |       0
+   1 |        6 |       0
+   2 |       18 |       3
+   3 |       31 |      11
+   4 |       56 |      19
+   5 |       73 |      38
+   6 |       90 |      66
+   7 |      110 |     103
+   8 |      125 |     148
+   9 |      146 |     196
+  10 |      151 |     252
+  11 |      147 |     318
+  12 |      148 |     382
+  13 |      167 |     437
+  14 |      160 |     520
+  15 |      147 |     592


### PR DESCRIPTION
# DCA Implementation

## dca.py 
- added the run_dca function. This function loads the data published by the xgboost, scores the ignition risk, builds the env_data, runs the DCA for n steps which will be changed when frontend implementation is added and then returns the full tick-by-tick burn-state history

## simluation.py
- has the functions that the run_dca() needs to score the ignition, build the env data and convert the PyTorchFire `[2,H,W]` bool state into the projects `[H,W]` integer burn-state codes

## run_ai_pipeline.py
- This is allows us to run the models with the synthetic weather/terrain grids, for manually verifying the output of the pipeline
